### PR TITLE
Add new data types to log and centraliza log inside message

### DIFF
--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -6,12 +6,21 @@ module Logist
   module Formatter
     class Json < ::Logger::Formatter
       def call(severity, timestamp, progname, msg)
-        begin
-          j = ::JSON.parse(msg)
-          temp = {level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env}.merge(j)
-          ::JSON.dump(temp) + "\n"
-        rescue JSON::ParserError
-          "{\"level\":\"#{severity}\",\"timestamp\":\"#{format_datetime(timestamp)}\",\"message\":\"#{msg}\",\"environment\":\"#{::Rails.env}\"}\n"
+        { level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env, message: format_message(msg) }.to_json + "\n"
+      end
+
+      def format_message(msg)
+        case msg.class.name
+          when "Hash"
+            msg
+          when "Array"
+            msg
+          else
+            begin
+              JSON.parse(msg)
+            rescue JSON::ParserError
+              "#{msg}"
+            end
         end
       end
     end

--- a/spec/formatter/json_spec.rb
+++ b/spec/formatter/json_spec.rb
@@ -14,7 +14,21 @@ RSpec.describe Logist::Formatter::Json do
   context "message is a json string" do
     let(:deserialized_output) { JSON.parse(formatter.call("debug", now, "", "{\"hoge\":\"fuga\"}")) }
     it do
-      expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), 'hoge' => 'fuga')
+      expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), 'message' => {'hoge' => 'fuga'})
+    end
+  end
+
+  context "message is a hash" do
+    let(:deserialized_output) { JSON.parse(formatter.call("debug", now, "", {k: "1", b: 2})) }
+    it do
+      expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), 'message' => { 'k' => '1', "b" => 2 })
+    end
+  end
+
+  context "message is a array" do
+    let(:deserialized_output) { JSON.parse(formatter.call("debug", now, "", [{hoge: "fuga"}])) }
+    it do
+      expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), "message"=>[{"hoge"=>"fuga"}])
     end
   end
 end


### PR DESCRIPTION
This PR has objective to centralize log inside key "message" to not make ambiguous data at the end.

- add new data types to job as json
- centralize log in message