### PR TITLE
Gracefully handle JSON parser errors

### DIFF
--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -6,13 +6,14 @@ module Logist
   module Formatter
     class Json < ::Logger::Formatter
       def call(severity, timestamp, progname, msg)
+        logobj = {level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env}
         begin
-          j = ::JSON.parse(msg)
-          temp = {level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env}.merge(j)
-          ::JSON.dump(temp) + "\n"
+          msg = ::JSON.parse(msg)
+          logobj.merge!(msg)
         rescue JSON::ParserError
-          "{\"level\":\"#{severity}\",\"timestamp\":\"#{format_datetime(timestamp)}\",\"message\":\"#{msg}\",\"environment\":\"#{::Rails.env}\"}\n"
+          logobj[:message] = msg
         end
+        ::JSON.dump(logobj) + "\n"
       end
     end
   end

--- a/spec/formatter/json_spec.rb
+++ b/spec/formatter/json_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe Logist::Formatter::Json do
     end
   end
 
+  context "message is a string with double quotes" do
+    let(:deserialized_output) { JSON.parse(formatter.call("debug", now, "", "test :message with \"quotes\"")) }
+    it do
+      expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), 'message' => 'test :message with "quotes"')
+    end
+  end
+
   context "message is a json string" do
     let(:deserialized_output) { JSON.parse(formatter.call("debug", now, "", "{\"hoge\":\"fuga\"}")) }
     it do


### PR DESCRIPTION
Hello,
the current implementation falls back to constructing a JSON string manually whenever there is an error parsing `msg`.
I changed this to use `JSON.dump` in any case.
The reason for this change is that, whenever msg contains double quotes of other "special" characters, the resulting JSON would be invalid because of lack of proper escaping. My change fixes the problem by building the JSON string through the json library.