### PR TITLE
 Changed to accept StandarError object.

### DIFF
--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -10,17 +10,14 @@ module Logist
       end
 
       def format_message(msg)
-        case msg.class.name
-          when "Hash"
-            msg
-          when "Array"
-            msg
-          else
-            begin
-              JSON.parse(msg)
-            rescue JSON::ParserError
-              "#{msg}"
-            end
+        if msg.is_a?(Hash) || msg.is_a?(Array) || msg.is_a?(StandardError)
+          msg
+        else
+          begin
+            JSON.parse(msg)
+          rescue JSON::ParserError
+            "#{msg}"
+          end
         end
       end
     end

--- a/spec/formatter/json_spec.rb
+++ b/spec/formatter/json_spec.rb
@@ -38,4 +38,11 @@ RSpec.describe Logist::Formatter::Json do
       expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), "message"=>[{"hoge"=>"fuga"}])
     end
   end
+
+  context "message is a StandardError" do
+    let(:deserialized_output) { JSON.parse(formatter.call("debug", now, "", StandardError.new("hoge"))) }
+    it do
+      expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), "message"=> "hoge")
+    end
+  end
 end


### PR DESCRIPTION
## Problem.

```ruby
def foo
  ...
rescue StandardError => e
  Rails.logger.error(e)
end
```

Error occurs when writing StandardError object to log.
```
TypeError: no implicit conversion of TypeError into String
```

I fixed StandardError and its subclass so that logger can receive it.