### PR TITLE
Add flat_json option for formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ Rails.application.configure do
 end
 ```
 
+### flat_json option
+
+If you want to log Hash object, but you don't want to have nested JSON, you can set `flat_json=true`:
+
+```ruby
+config.logger.formatter.flat_json = true
+```
+
+When `flat_json=false` (default):
+
+```json
+{"level":"INFO","message":{"foo":"bar"}}
+```
+
+When `flat_json=true`:
+
+```json
+{"level":"INFO","foo":"bar"}
+```
 
 
 ## Development

--- a/lib/logist/formatter/json.rb
+++ b/lib/logist/formatter/json.rb
@@ -5,23 +5,29 @@ require 'rails'
 module Logist
   module Formatter
     class Json < ::Logger::Formatter
-      def call(severity, timestamp, progname, msg)
-        { level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env, message: format_message(msg) }.to_json + "\n"
+      attr_accessor :flat_json
+
+      def call(severity, timestamp, progname, raw_msg)
+        msg = normalize_message(raw_msg)
+        payload = { level: severity, timestamp: format_datetime(timestamp), environment: ::Rails.env }
+
+        if flat_json && msg.is_a?(Hash)
+          payload.merge!(msg)
+        else
+          payload.merge!(message: msg)
+        end
+
+        payload.to_json << "\n"
       end
 
-      def format_message(msg)
-        case msg.class.name
-          when "Hash"
-            msg
-          when "Array"
-            msg
-          else
-            begin
-              JSON.parse(msg)
-            rescue JSON::ParserError
-              "#{msg}"
-            end
-        end
+      private
+
+      def normalize_message(raw_msg)
+        return raw_msg unless raw_msg.is_a?(String)
+
+        JSON.parse(raw_msg)
+      rescue JSON::ParserError
+        raw_msg
       end
     end
   end

--- a/lib/logist/logger.rb
+++ b/lib/logist/logger.rb
@@ -14,17 +14,18 @@ module Logist
     end
 
     def initialize(logdev, shift_age = 0, shift_size = 1048576, level: DEBUG,
-                   progname: nil, formatter: nil, datetime_format: nil,
+                   progname: nil, formatter: nil, datetime_format: nil, flat_json: false,
                    shift_period_suffix: '%Y%m%d')
       # I think that Logist should support other formats in the future.
       # But, as it is now, Logist only support json format.
       # So this line force json format all environments.
       @formatter = Logist::Formatter::Json.new
       @formatter.datetime_format = datetime_format
+      @formatter.flat_json = flat_json
       super(logdev, shift_age, shift_size, level: level,
             progname: progname, formatter: @formatter, datetime_format: datetime_format,
             shift_period_suffix: shift_period_suffix)
-      
+
       # https://github.com/rails/rails/pull/34055
       # even with ^ respond_to?(:after_initialize) is still true
       # but we know not to run it if ActiveSupport::LoggerSilence is defined, since that was added in the same rails version

--- a/spec/formatter/json_spec.rb
+++ b/spec/formatter/json_spec.rb
@@ -38,4 +38,29 @@ RSpec.describe Logist::Formatter::Json do
       expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), "message"=>[{"hoge"=>"fuga"}])
     end
   end
+
+  context "when flat_json=true" do
+    before do
+      formatter.flat_json = true
+    end
+
+    let(:deserialized_output) { JSON.parse(formatter.call("debug", now, "", message)) }
+
+    context "when message is a hash" do
+      let(:message) { { foo: "bar", xyz: "abc" } }
+
+      it 'merges the message with the main hash' do
+        expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), 'foo' => 'bar', 'xyz' => 'abc')
+      end
+    end
+
+    context "when message is something else" do
+      let(:message) { 'Something else' }
+
+
+      it "adds 'message' key to the main hash" do
+        expect(deserialized_output).to eq('level' => 'debug', 'environment' => Rails.env, 'timestamp' => now.strftime("%Y-%m-%dT%H:%M:%S.%6N "), 'message' => 'Something else')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses issue https://github.com/h3poteto/logist/issues/16

It adds `flat_json` boolean option, when it's set to `true` and message is a hash, the hash will be merged with the main hash (this way nested hash is avoided).

`flat_json=false` by default for backward compatibility.

If you merge this PR, please consider publish a new version to rubygems.

Thanks again.
Sergey.